### PR TITLE
add plans attribute to post endpoint

### DIFF
--- a/backend/handlers/network/post.py
+++ b/backend/handlers/network/post.py
@@ -138,6 +138,7 @@ class PostHandler(BaseTimelineHandler):
                 "tags": ["tag1", "tag2"], (json encoded list)
                 "space": "optional _id, post this post into a space, not directly into your profile",
                 "wordpress_post_id": "optional, id of associated wordpress post"
+                "plans": ["optional, list of plans to attach to the post"] (json encoded list)
             }
         return:
             200 OK,
@@ -180,9 +181,11 @@ class PostHandler(BaseTimelineHandler):
             text = self.get_body_argument("text")  # http_body['text']
             wordpress_post_id = self.get_body_argument("wordpress_post_id", None)
             tags = self.get_body_argument("tags")  # http_body['tags']
-            # convert tags to list, because formdata will send it as a string
+            plans = self.get_body_argument("plans", [])
+            # convert tags and plans to list, because formdata will send it as a string
             try:
                 tags = json.loads(tags)
+                plans = json.loads(plans)
             except Exception:
                 pass
             # if space is set, this post belongs to a space (only visible inside)
@@ -267,6 +270,7 @@ class PostHandler(BaseTimelineHandler):
                     "pinned": False,
                     "wordpress_post_id": wordpress_post_id,
                     "tags": tags,
+                    "plans": plans,
                     "files": files,
                     "comments": [],
                     "likers": [],
@@ -945,6 +949,7 @@ class RepostHandler(BaseHandler):
                         "post_id": "id_of__original_post",
                         "text": "new text for the repost",
                         "space": "space _id, the space where to post, None if no space"
+                        "plans": ["optional, list of plans to attach to the repost"] (json encoded list)
                     }
             or update existing repost:
                 http_body:
@@ -1118,6 +1123,10 @@ class RepostHandler(BaseHandler):
                 post["likers"] = []
                 post["comments"] = []
                 post["tags"] = []
+                if "plans" in http_body:
+                    post["plans"] = http_body["plans"]
+                else:
+                    post["plans"] = []
                 del post["_id"]
 
                 repost_id = post_manager.insert_repost(post)

--- a/backend/resources/network/post.py
+++ b/backend/resources/network/post.py
@@ -36,6 +36,7 @@ class Posts:
             "pinned",
             "wordpress_post_id",
             "tags",
+            "plans",
             "files",
             "comments",
             "likers",

--- a/backend/tests/api_tests.py
+++ b/backend/tests/api_tests.py
@@ -1268,6 +1268,7 @@ class PostHandlerTest(BaseApiTestCase):
                 "pinned": False,
                 "wordpress_post_id": None,
                 "tags": [],
+                "plans": [],
                 "files": [],
                 "comments": [],
                 "likers": [],
@@ -1326,6 +1327,7 @@ class PostHandlerTest(BaseApiTestCase):
                 "pinned": False,
                 "wordpress_post_id": None,
                 "tags": [],
+                "plans": [],
                 "files": [],
                 "comments": [],
                 "likers": [],
@@ -1370,6 +1372,7 @@ class PostHandlerTest(BaseApiTestCase):
                 "pinned": False,
                 "wordpress_post_id": None,
                 "tags": [],
+                "plans": [],
                 "files": [],
                 "comments": [],
                 "likers": [],
@@ -1430,6 +1433,7 @@ class PostHandlerTest(BaseApiTestCase):
                 "pinned": False,
                 "wordpress_post_id": None,
                 "tags": [],
+                "plans": [],
                 "files": [],
                 "comments": [],
                 "likers": [],
@@ -1446,9 +1450,13 @@ class PostHandlerTest(BaseApiTestCase):
         expect: successfully create a new post
         """
 
+        plan_id1 = ObjectId()
+        plan_id2 = ObjectId()
+
         request_json = {
             "text": "unittest_test_post",
             "tags": json.dumps(["tag1", "tag2"]),
+            "plans": json.dumps([str(plan_id1), str(plan_id2)]),
         }
 
         request = MultipartEncoder(fields=request_json)
@@ -1475,6 +1483,7 @@ class PostHandlerTest(BaseApiTestCase):
         self.assertEqual(ObjectId(response["inserted_post"]["_id"]), db_state["_id"])
         self.assertEqual(response["inserted_post"]["text"], db_state["text"])
         self.assertEqual(response["inserted_post"]["tags"], db_state["tags"])
+        self.assertEqual(response["inserted_post"]["plans"], db_state["plans"])
         # the author has enhanced profile information to check for
         self.assertIn("author", response["inserted_post"])
         self.assertIn("username", response["inserted_post"]["author"])
@@ -1529,6 +1538,7 @@ class PostHandlerTest(BaseApiTestCase):
             "pinned",
             "wordpress_post_id",
             "tags",
+            "plans",
             "files",
         ]
         self.assertTrue(all(key in db_state for key in expected_keys))
@@ -1538,6 +1548,7 @@ class PostHandlerTest(BaseApiTestCase):
         self.assertFalse(db_state["pinned"])
         self.assertIsNone(db_state["wordpress_post_id"])
         self.assertEqual(db_state["tags"], json.loads(request_json["tags"]))
+        self.assertEqual(db_state["plans"], json.loads(request_json["plans"]))
         self.assertEqual(db_state["files"], [])
 
     def test_post_create_post_space(self):
@@ -1548,6 +1559,7 @@ class PostHandlerTest(BaseApiTestCase):
         request_json = {
             "text": "unittest_test_post",
             "tags": json.dumps(["tag1", "tag2"]),
+            "plans": json.dumps([]),
             "space": str(self.test_space_id),
         }
 
@@ -1579,6 +1591,7 @@ class PostHandlerTest(BaseApiTestCase):
             "pinned",
             "wordpress_post_id",
             "tags",
+            "plans",
             "files",
         ]
         self.assertTrue(all(key in db_state for key in expected_keys))
@@ -1588,6 +1601,7 @@ class PostHandlerTest(BaseApiTestCase):
         self.assertFalse(db_state["pinned"])
         self.assertIsNone(db_state["wordpress_post_id"])
         self.assertEqual(db_state["tags"], json.loads(request_json["tags"]))
+        self.assertEqual(db_state["plans"], json.loads(request_json["plans"]))
         self.assertEqual(db_state["files"], [])
 
     def test_post_create_post_space_with_file(self):
@@ -1603,6 +1617,7 @@ class PostHandlerTest(BaseApiTestCase):
         request_json = {
             "text": "unittest_test_post",
             "tags": json.dumps(["tag1", "tag2"]),
+            "plans": json.dumps([]),
             "space": str(self.test_space_id),
             "file_amount": "1",
             "file0": (self.test_file_name, file, "text/plain"),
@@ -1641,6 +1656,7 @@ class PostHandlerTest(BaseApiTestCase):
             "pinned",
             "wordpress_post_id",
             "tags",
+            "plans",
             "files",
         ]
         self.assertTrue(all(key in db_state for key in expected_keys))
@@ -1650,6 +1666,7 @@ class PostHandlerTest(BaseApiTestCase):
         self.assertFalse(db_state["pinned"])
         self.assertIsNone(db_state["wordpress_post_id"])
         self.assertEqual(db_state["tags"], json.loads(request_json["tags"]))
+        self.assertEqual(db_state["plans"], json.loads(request_json["plans"]))
         self.assertEqual(
             db_state["files"],
             [
@@ -1747,6 +1764,7 @@ class PostHandlerTest(BaseApiTestCase):
                 "pinned": False,
                 "wordpress_post_id": None,
                 "tags": [],
+                "plans": [],
                 "files": [],
             }
         )
@@ -1792,6 +1810,7 @@ class PostHandlerTest(BaseApiTestCase):
                 "pinned": False,
                 "wordpress_post_id": None,
                 "tags": [],
+                "plans": [],
                 "files": [],
             }
         )
@@ -1842,6 +1861,7 @@ class PostHandlerTest(BaseApiTestCase):
                 "pinned": False,
                 "wordpress_post_id": None,
                 "tags": [],
+                "plans": [],
                 "files": [],
             }
         )
@@ -1884,6 +1904,7 @@ class PostHandlerTest(BaseApiTestCase):
                 "pinned": False,
                 "wordpress_post_id": None,
                 "tags": [],
+                "plans": [],
                 "files": [],
             }
         )
@@ -1926,6 +1947,7 @@ class PostHandlerTest(BaseApiTestCase):
                 "pinned": False,
                 "wordpress_post_id": None,
                 "tags": [],
+                "plans": [],
                 "files": [],
             }
         )
@@ -1974,6 +1996,7 @@ class PostHandlerTest(BaseApiTestCase):
                 "pinned": False,
                 "wordpress_post_id": None,
                 "tags": [],
+                "plans": [],
                 "files": [],
             }
         )
@@ -2000,6 +2023,7 @@ class PostHandlerTest(BaseApiTestCase):
                 "pinned": False,
                 "wordpress_post_id": None,
                 "tags": [],
+                "plans": [],
                 "files": [],
             }
         )
@@ -2031,6 +2055,7 @@ class PostHandlerTest(BaseApiTestCase):
                 "pinned": False,
                 "wordpress_post_id": None,
                 "tags": [],
+                "plans": [],
                 "files": [],
             }
         )
@@ -2057,6 +2082,7 @@ class PostHandlerTest(BaseApiTestCase):
                 "pinned": False,
                 "wordpress_post_id": None,
                 "tags": [],
+                "plans": [],
                 "files": [],
             }
         )
@@ -2095,6 +2121,7 @@ class PostHandlerTest(BaseApiTestCase):
                 "pinned": False,
                 "wordpress_post_id": None,
                 "tags": [],
+                "plans": [],
                 "files": [],
             }
         )
@@ -2134,6 +2161,7 @@ class PostHandlerTest(BaseApiTestCase):
                 "pinned": False,
                 "wordpress_post_id": None,
                 "tags": [],
+                "plans": [],
                 "files": [
                     {
                         "file_id": _id,
@@ -2202,6 +2230,7 @@ class PostHandlerTest(BaseApiTestCase):
                 "pinned": False,
                 "wordpress_post_id": None,
                 "tags": [],
+                "plans": [],
                 "files": [],
             }
         )
@@ -2234,6 +2263,7 @@ class PostHandlerTest(BaseApiTestCase):
                 "pinned": False,
                 "wordpress_post_id": None,
                 "tags": [],
+                "plans": [],
                 "files": [],
             }
         )
@@ -2261,6 +2291,7 @@ class CommentHandlerTest(BaseApiTestCase):
                 "pinned": False,
                 "wordpress_post_id": None,
                 "tags": [],
+                "plans": [],
                 "files": [],
             }
         )

--- a/backend/tests/resource_tests.py
+++ b/backend/tests/resource_tests.py
@@ -1004,6 +1004,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [self.default_comment],
             "likers": [],
@@ -1071,6 +1072,7 @@ class PostResourceTest(BaseResourceTestCase):
             post["wordpress_post_id"], self.default_post["wordpress_post_id"]
         )
         self.assertEqual(post["tags"], self.default_post["tags"])
+        self.assertEqual(post["plans"], self.default_post["plans"])
         self.assertEqual(post["files"], self.default_post["files"])
         self.assertEqual(post["comments"], self.default_post["comments"])
         self.assertEqual(post["likers"], self.default_post["likers"])
@@ -1089,6 +1091,7 @@ class PostResourceTest(BaseResourceTestCase):
             post["wordpress_post_id"], self.default_post["wordpress_post_id"]
         )
         self.assertEqual(post["tags"], self.default_post["tags"])
+        self.assertEqual(post["plans"], self.default_post["plans"])
         self.assertEqual(post["files"], self.default_post["files"])
         self.assertEqual(post["comments"], self.default_post["comments"])
         self.assertEqual(post["likers"], self.default_post["likers"])
@@ -1122,6 +1125,7 @@ class PostResourceTest(BaseResourceTestCase):
             post["wordpress_post_id"], self.default_post["wordpress_post_id"]
         )
         self.assertEqual(post["tags"], self.default_post["tags"])
+        self.assertEqual(post["plans"], self.default_post["plans"])
         self.assertEqual(post["files"], self.default_post["files"])
         self.assertEqual(post["comments"], self.default_post["comments"])
         self.assertEqual(post["likers"], self.default_post["likers"])
@@ -1140,6 +1144,7 @@ class PostResourceTest(BaseResourceTestCase):
             post["wordpress_post_id"], self.default_post["wordpress_post_id"]
         )
         self.assertEqual(post["tags"], self.default_post["tags"])
+        self.assertEqual(post["plans"], self.default_post["plans"])
         self.assertEqual(post["files"], self.default_post["files"])
         self.assertEqual(post["comments"], self.default_post["comments"])
         self.assertEqual(post["likers"], self.default_post["likers"])
@@ -1162,6 +1167,7 @@ class PostResourceTest(BaseResourceTestCase):
                 "isRepost": False,
                 "wordpress_post_id": None,
                 "tags": ["test", "test2"],
+                "plans": [],
                 "files": [],
                 "comments": [],
                 "likers": [],
@@ -1177,6 +1183,7 @@ class PostResourceTest(BaseResourceTestCase):
                 "isRepost": False,
                 "wordpress_post_id": None,
                 "tags": ["test2", "test3"],
+                "plans": [],
                 "files": [],
                 "comments": [],
                 "likers": [],
@@ -1211,6 +1218,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -1230,6 +1238,7 @@ class PostResourceTest(BaseResourceTestCase):
         self.assertEqual(post["isRepost"], new_post["isRepost"])
         self.assertEqual(post["wordpress_post_id"], new_post["wordpress_post_id"])
         self.assertEqual(post["tags"], new_post["tags"])
+        self.assertEqual(post["plans"], new_post["plans"])
         self.assertEqual(post["files"], new_post["files"])
         self.assertEqual(post["comments"], new_post["comments"])
         self.assertEqual(post["likers"], new_post["likers"])
@@ -1248,6 +1257,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -1272,6 +1282,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],  # change this too, expecting it to not be updated
             "likers": [],
@@ -1294,6 +1305,7 @@ class PostResourceTest(BaseResourceTestCase):
         self.assertEqual(post["isRepost"], new_post["isRepost"])
         self.assertEqual(post["wordpress_post_id"], new_post["wordpress_post_id"])
         self.assertEqual(post["tags"], new_post["tags"])
+        self.assertEqual(post["plans"], new_post["plans"])
         self.assertEqual(post["files"], new_post["files"])
         self.assertEqual(post["likers"], new_post["likers"])
 
@@ -1312,6 +1324,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -1373,6 +1386,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [
                 {
                     "file_id": file_id,
@@ -1439,6 +1453,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [
                 {
                     "file_id": file_id,
@@ -1493,6 +1508,7 @@ class PostResourceTest(BaseResourceTestCase):
                 "isRepost": False,
                 "wordpress_post_id": None,
                 "tags": ["test"],
+                "plans": [],
                 "files": [],
                 "comments": [],
                 "likers": [],
@@ -1507,6 +1523,7 @@ class PostResourceTest(BaseResourceTestCase):
                 "isRepost": False,
                 "wordpress_post_id": None,
                 "tags": ["test"],
+                "plans": [],
                 "files": [],
                 "comments": [],
                 "likers": [],
@@ -1725,6 +1742,7 @@ class PostResourceTest(BaseResourceTestCase):
             "pinned": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -1747,6 +1765,7 @@ class PostResourceTest(BaseResourceTestCase):
         self.assertEqual(post["pinned"], repost["pinned"])
         self.assertEqual(post["wordpress_post_id"], repost["wordpress_post_id"])
         self.assertEqual(post["tags"], repost["tags"])
+        self.assertEqual(post["plans"], repost["plans"])
         self.assertEqual(post["files"], repost["files"])
         self.assertEqual(post["comments"], repost["comments"])
         self.assertEqual(post["likers"], repost["likers"])
@@ -1771,6 +1790,7 @@ class PostResourceTest(BaseResourceTestCase):
             "pinned": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -1792,6 +1812,7 @@ class PostResourceTest(BaseResourceTestCase):
             "pinned": True,  # changed, but shouldnt be updated
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -1816,6 +1837,7 @@ class PostResourceTest(BaseResourceTestCase):
         self.assertNotEqual(post["pinned"], repost["pinned"])
         self.assertEqual(post["wordpress_post_id"], repost["wordpress_post_id"])
         self.assertEqual(post["tags"], repost["tags"])
+        self.assertEqual(post["plans"], repost["plans"])
         self.assertEqual(post["files"], repost["files"])
         self.assertEqual(post["comments"], repost["comments"])
         self.assertEqual(post["likers"], repost["likers"])
@@ -1837,6 +1859,7 @@ class PostResourceTest(BaseResourceTestCase):
             "pinned": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -1858,6 +1881,7 @@ class PostResourceTest(BaseResourceTestCase):
             "pinned": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -1884,6 +1908,7 @@ class PostResourceTest(BaseResourceTestCase):
             "pinned": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -2047,6 +2072,7 @@ class PostResourceTest(BaseResourceTestCase):
                 "isRepost": False,
                 "wordpress_post_id": None,
                 "tags": ["test"],
+                "plans": [],
                 "files": [],
                 "comments": [],
                 "likers": [],
@@ -2078,6 +2104,7 @@ class PostResourceTest(BaseResourceTestCase):
                 "isRepost": False,
                 "wordpress_post_id": None,
                 "tags": ["test"],
+                "plans": [],
                 "files": [],
                 "comments": [],
                 "likers": [],
@@ -2097,6 +2124,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -2129,6 +2157,7 @@ class PostResourceTest(BaseResourceTestCase):
                 "isRepost": False,
                 "wordpress_post_id": None,
                 "tags": ["test"],
+                "plans": [],
                 "files": [],
                 "comments": [],
                 "likers": [],
@@ -2169,6 +2198,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -2183,6 +2213,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -2215,6 +2246,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -2229,6 +2261,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -2245,6 +2278,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -2262,6 +2296,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -2309,6 +2344,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -2323,6 +2359,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -2355,6 +2392,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -2369,6 +2407,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],
@@ -2385,6 +2424,7 @@ class PostResourceTest(BaseResourceTestCase):
             "isRepost": False,
             "wordpress_post_id": None,
             "tags": ["test"],
+            "plans": [],
             "files": [],
             "comments": [],
             "likers": [],


### PR DESCRIPTION
@simeonackermann there u go :)
mit dem FormData ist etwas blöd, weil man da keine Listen rein packen kann, deshalb ist es als json-encoded string: '["plan_id1", "plan_id2"]'